### PR TITLE
Proposing id-length rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ module.exports = {
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "object-shorthand": ["error", "properties", { "avoidQuotes": true }],
     "react/jsx-uses-react": "error",
-    "react/jsx-uses-vars": "error"
+    "react/jsx-uses-vars": "error",
+    "id-length": ["error", {"exceptions": ["n", "m", "i", "j", "k"]}]
   },
   "env": {
     "node": true,


### PR DESCRIPTION
Exceptions are added for common loop variables because I think `for(let i = 0; i < 10; i++)` is good code but in all other cases it sucks.
