### PR TITLE
Add object-curly-newline and object-property-newline.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,14 @@ module.exports = {
     'react/jsx-filename-extension': ['error', {
       extensions: ['.js', '.jsx'],
     }],
+    
+    
+    // require newlines for closing curlies iff the object itself is on multiple lines.
+    'object-curly-newline': ['error', { 'multiline': true }],
+    
+    // require properties to be on their own line iff there are multiple lines
+    // allowMultiplePropertiesPerLine allows there to be EITHER all properties on one line, or all on their own line, but not both.
+    'object-property-newline': ['error', { 'allowMultiplePropertiesPerLine': true }],
 
     // override of airbnb indent rule to enable MemberExpressions option
     'indent': ['error', 2, {


### PR DESCRIPTION
Adding rules to make this an error:

<img width="576" alt="screen shot 2017-02-07 at 12 14 51 pm" src="https://cloud.githubusercontent.com/assets/780031/22709559/13fb0654-ed2f-11e6-828f-772d7f975156.png">

Relevant ESLint pages: 
 http://eslint.org/docs/rules/object-curly-newline
 http://eslint.org/docs/rules/object-property-newline
